### PR TITLE
Fix export_limit None return

### DIFF
--- a/limit-control.py
+++ b/limit-control.py
@@ -149,7 +149,7 @@ def set_multiplus_power_limit(limit_watts, vebus_device=None):
     else:
         vebus_devices = [vebus_device]
     
-        for device in vebus_devices:
+    for device in vebus_devices:
         success = False
         
         try:

--- a/v2.0-minimal/limit-control-v2.py
+++ b/v2.0-minimal/limit-control-v2.py
@@ -13,6 +13,14 @@ def get_power(path):
     except Exception:
         return 0
 
+def get_export_limit():
+    try:
+        obj = BUS.get_object('com.victronenergy.settings', '/Settings/CGwacs/AcPowerSetPoint')
+        iface = dbus.Interface(obj, 'com.victronenergy.BusItem')
+        return int(iface.GetValue())
+    except Exception:
+        return 0
+
 def set_export_limit(value):
     try:
         obj = BUS.get_object('com.victronenergy.settings', '/Settings/CGwacs/AcPowerSetPoint')


### PR DESCRIPTION
Add `get_export_limit` to prevent `None` returns and fix an indentation error in `limit-control.py`.

The indentation error in `limit-control.py` would have caused a `SyntaxError` preventing the `set_multiplus_power_limit` function from executing correctly. The new `get_export_limit` function in `v2.0-minimal/limit-control-v2.py` ensures the export limit is retrieved reliably, returning `0` on error instead of `None`.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-efb00d95-6571-4919-bf1f-0c3b8b3c878c) · [Cursor](https://cursor.com/background-agent?bcId=bc-efb00d95-6571-4919-bf1f-0c3b8b3c878c)

[Slack Thread](https://trohheus.slack.com/archives/D096PMETJ2J/p1753120789852179?thread_ts=1753120789.852179&cid=D096PMETJ2J)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)