### PR TITLE
Fix export limit None bug

### DIFF
--- a/v2.0-minimal/limit-control-v2.py
+++ b/v2.0-minimal/limit-control-v2.py
@@ -13,6 +13,16 @@ def get_power(path):
     except Exception:
         return 0
 
+def get_export_limit():
+    """Reads current AC Power SetPoint from the com.victronenergy.settings service"""
+    try:
+        obj = BUS.get_object('com.victronenergy.settings', '/Settings/CGwacs/AcPowerSetPoint')
+        iface = dbus.Interface(obj, 'com.victronenergy.BusItem')
+        value = iface.GetValue()
+        return int(value) if value is not None else None
+    except Exception:
+        return None
+
 def set_export_limit(value):
     try:
         obj = BUS.get_object('com.victronenergy.settings', '/Settings/CGwacs/AcPowerSetPoint')


### PR DESCRIPTION
Fix bug where `export_limit` returned `None` by adding `get_export_limit()` function.

Previously, only `set_export_limit()` existed, leading to no mechanism to retrieve the current export limit from the DBus system.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-5e007982-26f0-4c61-b195-07c07522c0a1) · [Cursor](https://cursor.com/background-agent?bcId=bc-5e007982-26f0-4c61-b195-07c07522c0a1)

[Slack Thread](https://trohheus.slack.com/archives/D096PMETJ2J/p1753120789852179?thread_ts=1753120789.852179&cid=D096PMETJ2J)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)